### PR TITLE
HW-52643  UI-Translate time / date / clock to Device Timezone

### DIFF
--- a/Sources/Extensions/Date.swift
+++ b/Sources/Extensions/Date.swift
@@ -19,6 +19,25 @@
 import Foundation
 
 extension Date {
+    enum DateFormatMode {
+        case listView
+        case detailView
+    }
+
+    private static let dateFormatterForListView: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("yMMMd")
+        formatter.formattingContext = .beginningOfSentence
+        return formatter
+    }()
+
+    private static let dateFormatterForDetailView: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("yMMMEdjm")
+        formatter.formattingContext = .beginningOfSentence
+        return formatter
+    }()
+
     func formatDateToString(dateStyle: DateFormatter.Style = DateFormatter.Style.medium,
                             timeStyle: DateFormatter.Style = DateFormatter.Style.medium) -> String {
         let dateFormatter = DateFormatter()
@@ -37,5 +56,15 @@ extension Date {
         let calendar = Calendar.current
         let components = calendar.dateComponents([.year, .month], from: self)
         return calendar.date(from: components)!
+    }
+
+    func format(for formatMode: DateFormatMode) -> String {
+        switch formatMode {
+        case .listView:
+            return Date.dateFormatterForListView.string(from: self)
+
+        case .detailView:
+            return Date.dateFormatterForDetailView.string(from: self)
+        }
     }
 }


### PR DESCRIPTION
[HW-52643](https://jira.site1.hyperwallet.local/browse/HW-52643) UI-Translate time / date / clock to Device Timezone
[HW-52946](https://jira.site1.hyperwallet.local/browse/HW-52946) Update ListReceiptTableViewCell

Implemented localized date/time formatting, e.g.
en_CA, en_US--- Fri, May 31, 2019, 3:32 PM
es_MX---------- Vie, 31 de mayo de 2019 15:34
hi_IN------------ शुक्र, ३१ मई २०१९, अ ३:३९
zh_Hans_CN---- 2019年5月31日 周五 下午3:40
ja_JP----------- 2019年5月31日(金) 15:41
uk_UA---------- Пт, 31 трав. 2019, 15:33
 
Chinese, Simplified
<img src="https://user-images.githubusercontent.com/48257589/58720504-0666fd00-83db-11e9-8889-53fcfc4e4ac0.png" alt="drawing" width="250"/>