### PR TITLE
Task/hw 53264 update ui tests to use accessibility id transaction details

### DIFF
--- a/HyperwalletUISDK.xcodeproj/project.pbxproj
+++ b/HyperwalletUISDK.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		09E7165022A697C400FA9B96 /* ReceiptsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E7164F22A697C400FA9B96 /* ReceiptsList.swift */; };
 		09E7165622A6983400FA9B96 /* ListReceiptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E7165522A6983400FA9B96 /* ListReceiptTests.swift */; };
 		412F723722B45DB100837F8F /* TransactionDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412F723222B458C700837F8F /* TransactionDetails.swift */; };
-		412F723922B46B1000837F8F /* TransactionDetailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412F723822B46B1000837F8F /* TransactionDetailTests.swift */; };
 		4A12653C2280B02900C0F59E /* DateWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A12653B2280B02900C0F59E /* DateWidget.swift */; };
 		4A12653E2280B12F00C0F59E /* PhoneWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A12653D2280B12F00C0F59E /* PhoneWidget.swift */; };
 		4A22F1E422A6723200D58883 /* ReceiptDetailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A22F1E322A6723200D58883 /* ReceiptDetailTableViewController.swift */; };
@@ -230,7 +229,6 @@
 		09E7164F22A697C400FA9B96 /* ReceiptsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptsList.swift; sourceTree = "<group>"; };
 		09E7165522A6983400FA9B96 /* ListReceiptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListReceiptTests.swift; sourceTree = "<group>"; };
 		412F723222B458C700837F8F /* TransactionDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetails.swift; sourceTree = "<group>"; };
-		412F723822B46B1000837F8F /* TransactionDetailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailTests.swift; sourceTree = "<group>"; };
 		4A12653B2280B02900C0F59E /* DateWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateWidget.swift; sourceTree = "<group>"; };
 		4A12653D2280B12F00C0F59E /* PhoneWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneWidget.swift; sourceTree = "<group>"; };
 		4A22F1E322A6723200D58883 /* ReceiptDetailTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptDetailTableViewController.swift; sourceTree = "<group>"; };
@@ -477,7 +475,6 @@
 			isa = PBXGroup;
 			children = (
 				09E7165522A6983400FA9B96 /* ListReceiptTests.swift */,
-				412F723822B46B1000837F8F /* TransactionDetailTests.swift */,
 			);
 			path = Receipts;
 			sourceTree = "<group>";
@@ -1165,7 +1162,6 @@
 				C3E7217A226F93860067D3A0 /* XCUIDevice.swift in Sources */,
 				412F723722B45DB100837F8F /* TransactionDetails.swift in Sources */,
 				641324E1229575EC00512816 /* BaseTest.swift in Sources */,
-				412F723922B46B1000837F8F /* TransactionDetailTests.swift in Sources */,
 				C38DC07922727F9300B1F00E /* SelectTransferMethodCountryType.swift in Sources */,
 				DBB2B7132261C142006C48D3 /* HyperwalletMockWebServer.swift in Sources */,
 				DBB2B7142261C142006C48D3 /* ListTransferMethodTests.swift in Sources */,

--- a/UITests/Helper/Receipts/TransactionDetails.swift
+++ b/UITests/Helper/Receipts/TransactionDetails.swift
@@ -2,10 +2,11 @@ import XCTest
 
 class TransactionDetails {
     var navigationBar: XCUIElement
-    var receiptDetailTableviewTable: XCUIElement
+    // Sections
     var detailSection: XCUIElement
     var feeSection: XCUIElement
     var transactionSection: XCUIElement
+    // Payment
     var cellTextLabel: XCUIElement
     var detailTextLabel: XCUIElement
     var detailHeaderTitle: XCUIElement
@@ -25,29 +26,51 @@ class TransactionDetails {
     // Back button
     var backButton: XCUIElement
 
+    // Values label
+    var receiptIdValue: XCUIElement
+    var dateValue: XCUIElement
+    var clientTransactionIdValue: XCUIElement
+    var charityNameValue: XCUIElement
+    var checkNumValue: XCUIElement
+    var websiteValue: XCUIElement
+    var notesValue: XCUIElement
+    var amountValue: XCUIElement
+    var feeValue: XCUIElement
+    var transactionValue: XCUIElement
+
     var app: XCUIApplication
 
     init(app: XCUIApplication) {
         self.app = app
         navigationBar = app.navigationBars["Transaction Details"]
         detailHeaderTitle = app.navigationBars["Transaction Details"].otherElements["Transaction Details"]
-        receiptDetailTableviewTable = app.tables["receiptDetailTableView"]
-        cellTextLabel = receiptDetailTableviewTable.staticTexts["ListReceiptTableViewCellTextLabel"]
-        detailTextLabel = receiptDetailTableviewTable.staticTexts["ListReceiptTableViewDetailTextLabel"]
-        detailSection = receiptDetailTableviewTable.staticTexts["Details"]
-        feeSection = receiptDetailTableviewTable.staticTexts["Fee Specification"]
-        transactionSection = receiptDetailTableviewTable.staticTexts["Transaction"]
-        receiptIdLabel = receiptDetailTableviewTable.staticTexts["Receipt ID:"]
-        dateLabel = receiptDetailTableviewTable.staticTexts["Date:"]
-        clientTransactionIdLabel = receiptDetailTableviewTable.staticTexts["Client Transaction ID:"]
-        charityNameLabel = receiptDetailTableviewTable.staticTexts["Charity Name:"]
-        checkNumLabel = receiptDetailTableviewTable.staticTexts["Check Number:"]
-        promoWebSiteLabel = receiptDetailTableviewTable.staticTexts["Promo Website:"]
-        noteSectionLabel = receiptDetailTableviewTable.staticTexts["Notes"]
-        amountLabel = receiptDetailTableviewTable.staticTexts["Amount:"]
-        feeLabel = receiptDetailTableviewTable.staticTexts["Fee:"]
-        transactionLabel = receiptDetailTableviewTable.staticTexts["Transaction:"]
+        cellTextLabel = app.tables["receiptDetailTableView"].staticTexts["ListReceiptTableViewCellTextLabel"]
+        detailTextLabel = app.tables["receiptDetailTableView"].staticTexts["ListReceiptTableViewDetailTextLabel"]
+        detailSection = app.tables["receiptDetailTableView"].staticTexts["Details"]
+        feeSection = app.tables["receiptDetailTableView"].staticTexts["Fee Specification"]
+        transactionSection = app.tables["receiptDetailTableView"].staticTexts["Transaction"]
+        receiptIdLabel = app.tables["receiptDetailTableView"].staticTexts["Receipt ID:"]
+        dateLabel = app.tables["receiptDetailTableView"].staticTexts["Date:"]
+        clientTransactionIdLabel = app.tables["receiptDetailTableView"].staticTexts["Client Transaction ID:"]
+        charityNameLabel = app.tables["receiptDetailTableView"].staticTexts["Charity Name:"]
+        checkNumLabel = app.tables["receiptDetailTableView"].staticTexts["Check Number:"]
+        promoWebSiteLabel = app.tables["receiptDetailTableView"].staticTexts["Promo Website:"]
+        noteSectionLabel = app.tables["receiptDetailTableView"].staticTexts["Notes"]
+        amountLabel = app.tables["receiptDetailTableView"].staticTexts["Amount:"]
+        feeLabel = app.tables["receiptDetailTableView"].staticTexts["Fee:"]
+        transactionLabel = app.tables["receiptDetailTableView"].staticTexts["Transaction:"]
         backButton = navigationBar.children(matching: .button).matching(identifier: "Back").element(boundBy: 0)
+
+        receiptIdValue = app.tables["receiptDetailTableView"].staticTexts["Receipt ID:_value"]
+        dateValue = app.tables["receiptDetailTableView"].staticTexts["Date:_value"]
+        clientTransactionIdValue = app.tables["receiptDetailTableView"].staticTexts["Client Transaction ID:_value"]
+        charityNameValue = app.tables["receiptDetailTableView"].staticTexts["Charity Name:_value"]
+        checkNumValue = app.tables["receiptDetailTableView"].staticTexts["Check Number:_value"]
+        websiteValue = app.tables["receiptDetailTableView"].staticTexts["Promo Website:_value"]
+        notesValue = app.tables["receiptDetailTableView"].staticTexts["ReceiptDetailSectionNotesTextLabel"]
+        amountValue = app.tables["receiptDetailTableView"].staticTexts["Amount:_value"]
+        feeValue = app.tables["receiptDetailTableView"].staticTexts["Fee:_value"]
+        transactionValue = app.tables["receiptDetailTableView"].staticTexts["Transaction:_value"]
     }
 
     func openReceipt(row: Int) {

--- a/UITests/Receipts/ListReceiptTests.swift
+++ b/UITests/Receipts/ListReceiptTests.swift
@@ -297,9 +297,7 @@ class ListReceiptTests: BaseTests {
 
     // MARK: Helper methods
     private func openupReceiptsListScreenForOneMonth() {
-        mockServer.setupStub(url: "/rest/v3/users/usr-token/receipts",
-                             filename: "ReceiptsForOneMonth",
-                              method: HTTPMethod.get)
+        mockServer.setupStub(url: "/rest/v3/users/usr-token/receipts", filename: "ReceiptsForOneMonth", method: HTTPMethod.get)
 
         openReceiptsListScreen()
     }

--- a/UITests/Receipts/ListReceiptTests.swift
+++ b/UITests/Receipts/ListReceiptTests.swift
@@ -1,12 +1,15 @@
 import XCTest
 
 class ListReceiptTests: BaseTests {
+    private let currency = "USD"
     var receiptsList: ReceiptsList!
+    private var transactDetails: TransactionDetails!
 
     override func setUp() {
         profileType = .individual
         super.setUp()
         receiptsList = ReceiptsList(app: app)
+        transactDetails = TransactionDetails(app: app)
         spinner = app.activityIndicators["activityIndicator"]
     }
 
@@ -193,5 +196,166 @@ class ListReceiptTests: BaseTests {
     private func openReceiptsListScreen() {
         app.tables.cells.containing(.staticText, identifier: "List User Receipts").element(boundBy: 0).tap()
         waitForNonExistence(spinner)
+    }
+
+    // MARK: Detail Page Testcases
+
+    // Credit Transaction
+    func testReceiptDetail_verifyCreditTransaction() {
+        let expectedDateValue = "Fri, May 24, 2019, 6:16 PM"
+        openupReceiptsListScreenForFewMonths()
+        transactDetails.openReceipt(row: 0)
+        let transactionDetailHeaderLabel = transactDetails.detailHeaderTitle
+        waitForNonExistence(transactionDetailHeaderLabel)
+        if #available(iOS 12, *) {
+            verifyPayment(payment: "Payment\nMay 24, 2019", amount: "+6.00\n\(currency)")
+        } else {
+            verifyPayment(payment: "Payment May 24, 2019", amount: "+6.00 \(currency)")
+        }
+
+        // DETAILS Section
+        verifyDetailSection(receiptIdVal: "55176992", dateVal: expectedDateValue, clientIdVal: "DyClk0VG9a")
+
+        // FEE Section
+        verifyFeeSection(amountVal: "+6.00 USD", feeVal: "0.00 USD", transactionVal: "6.00 USD")
+    }
+
+    // Debit Transaction
+    func testReceiptDetail_verifyDebitTransaction() {
+        let expectedDateValue = "Sun, May 12, 2019, 6:16 PM" // Sun, May 12, 2019, 6:16 PM
+        openupReceiptsListScreenForFewMonths()
+        transactDetails.openReceipt(row: 1)
+        let transactionDetailHeaderLabel = transactDetails.detailHeaderTitle
+        waitForNonExistence(transactionDetailHeaderLabel)
+
+        if #available(iOS 12, *) {
+            verifyPayment(payment: "Bank Account\nMay 12, 2019", amount: "-5.00\n\(currency)")
+        } else {
+            verifyPayment(payment: "Bank Account May 12, 2019", amount: "-5.00 \(currency)")
+        }
+
+        // DETAILS Section
+        verifyDetailSection(receiptIdVal: "55176991", dateVal: expectedDateValue, clientIdVal: nil)
+
+        // FEE Section
+        verifyFeeSection(amountVal: "-5.00 USD", feeVal: "2.00 USD", transactionVal: "-7.00 USD")
+    }
+
+    func testReceiptDetail_verifyTransactionOptionalFields() {
+        openupReceiptsListScreenForOneMonth()
+        transactDetails.openReceipt(row: 4)
+        let transactionDetailHeaderLabel = transactDetails.detailHeaderTitle
+        waitForNonExistence(transactionDetailHeaderLabel)
+
+        let clienTransactionLabel = transactDetails.clientTransactionIdLabel
+        let detailsSectionLabel = transactDetails.detailSection
+        let receiptLabel = transactDetails.receiptIdLabel
+        let dateLabel = transactDetails.dateLabel
+        let charityLabel = transactDetails.charityNameLabel
+        let checkNumLabel = transactDetails.checkNumLabel
+        let websiteLabel = transactDetails.promoWebSiteLabel
+        let noteSection = transactDetails.noteSectionLabel
+        let receiptId = transactDetails.receiptIdValue
+        let date = transactDetails.dateValue
+        let transactionId = transactDetails.clientTransactionIdValue
+        let charityName = transactDetails.charityNameValue
+        let checkNum = transactDetails.checkNumValue
+        let website = transactDetails.websiteValue
+        let notes = transactDetails.notesValue
+
+        XCTAssertTrue(clienTransactionLabel.exists)
+        XCTAssertTrue(detailsSectionLabel.exists)
+        XCTAssertTrue(receiptLabel.exists)
+        XCTAssertTrue(dateLabel.exists)
+        XCTAssertTrue(charityLabel.exists)
+        XCTAssertTrue(checkNumLabel.exists)
+        XCTAssertTrue(websiteLabel.exists)
+        XCTAssertTrue(noteSection.exists)
+        XCTAssertEqual(receiptId.label, "3051579")
+        XCTAssertEqual(transactionId.label, "8OxXefx5")
+        XCTAssertEqual(charityName.label, "Sample Charity")
+        XCTAssertEqual(checkNum.label, "Sample Check Number")
+        XCTAssertEqual(website.label, "https://localhost")
+        XCTAssertEqual(notes.label, "Sample payment for the period of June 15th, 2019 to July 23, 2019")
+
+        XCTAssertEqual(date.label, "Fri, May 3, 2019, 5:08 PM") // // Fri, May 3, 2019, 5:08 PM in test environment
+    }
+
+    // Verify when no Notes and Fee sections
+    func testReceiptDetail_verifyTransactionReceiptNoNoteSectionAndFeeLabel() {
+       openupReceiptsListScreenForOneMonth()
+        transactDetails.openReceipt(row: 2)
+        let transactionDetailHeaderLabel = transactDetails.detailHeaderTitle
+        waitForNonExistence(transactionDetailHeaderLabel)
+
+        // Assert No Note and Fee sections
+        let noteSection = transactDetails.noteSectionLabel
+        let feeLabel = transactDetails.feeLabel
+        XCTAssertFalse(noteSection.exists)
+        XCTAssertFalse(feeLabel.exists)
+    }
+
+    // MARK: Helper methods
+    private func openupReceiptsListScreenForOneMonth() {
+        mockServer.setupStub(url: "/rest/v3/users/usr-token/receipts",
+                             filename: "ReceiptsForOneMonth",
+                              method: HTTPMethod.get)
+
+        openReceiptsListScreen()
+    }
+
+    private func verifyPayment(payment: String, amount: String) {
+        let paymentlabel = app.tables["receiptDetailTableView"].staticTexts["ListReceiptTableViewCellTextLabel"].label
+        let amountlabel = app.tables["receiptDetailTableView"].staticTexts["ListReceiptTableViewCellDetailTextLabel"].label
+        XCTAssertEqual(paymentlabel, payment)
+        XCTAssertEqual(amountlabel, amount)
+    }
+
+    // Detail section verification
+    private func verifyDetailSection(receiptIdVal: String, dateVal: String, clientIdVal: String?) {
+        let detailsSectionLabel = transactDetails.detailSection
+        let receiptLabel = transactDetails.receiptIdLabel
+        let dateLabel = transactDetails.dateLabel
+        let receiptID = transactDetails.receiptIdValue
+        let date = transactDetails.dateValue
+
+        XCTAssertTrue(detailsSectionLabel.exists)
+        XCTAssertTrue(receiptLabel.exists)
+        XCTAssertTrue(dateLabel.exists)
+        XCTAssertTrue(receiptID.exists)
+        XCTAssertEqual(receiptID.label, receiptIdVal)
+
+        XCTAssertEqual(date.label, dateVal)
+
+        if let clientIdVal = clientIdVal {
+            let clientTransIDLabel = transactDetails.clientTransactionIdLabel
+            XCTAssertTrue(clientTransIDLabel.exists)
+            let clientID = transactDetails.clientTransactionIdValue
+            XCTAssertTrue(clientID.exists)
+            XCTAssertEqual(clientID.label, clientIdVal)
+        }
+    }
+
+    // FEE section verification
+    private func verifyFeeSection(amountVal: String, feeVal: String, transactionVal: String) {
+        let feeSectionLabel = transactDetails.feeSection
+        let amountLabel = transactDetails.amountLabel
+        let feeLabel = transactDetails.feeLabel
+        let transactionLabel = transactDetails.transactionLabel
+        let amount = transactDetails.amountValue
+        let fee = transactDetails.feeValue
+        let transaction = transactDetails.transactionValue
+
+        XCTAssertTrue(feeSectionLabel.exists)
+        XCTAssertTrue(amountLabel.exists)
+        XCTAssertTrue(feeLabel.exists)
+        XCTAssertTrue(transactionLabel.exists)
+        XCTAssertTrue(amount.exists)
+        XCTAssertTrue(fee.exists)
+        XCTAssertTrue(transaction.exists)
+
+        XCTAssertEqual(amount.label, amountVal)
+        XCTAssertEqual(fee.label, feeVal)
+        XCTAssertEqual(transaction.label, transactionVal)
     }
 }

--- a/UITests/Receipts/TransactionDetailTests.swift
+++ b/UITests/Receipts/TransactionDetailTests.swift
@@ -99,21 +99,19 @@ class TransactionDetailTests: BaseTests {
     }
 
     private func verifyPayment(payment: String, amount: String) {
-        let receiptDetailTableviewTable = transactDetails.receiptDetailTableviewTable
-        let paymentlabel = receiptDetailTableviewTable.staticTexts["ListReceiptTableViewCellTextLabel"].label
-        let amountlabel = receiptDetailTableviewTable.staticTexts["ListReceiptTableViewCellDetailTextLabel"].label
+        let paymentlabel = app.tables["receiptDetailTableView"].staticTexts["ListReceiptTableViewCellTextLabel"].label
+        let amountlabel = app.tables["receiptDetailTableView"].staticTexts["ListReceiptTableViewCellDetailTextLabel"].label
         XCTAssertEqual(paymentlabel, payment)
         XCTAssertEqual(amountlabel, amount)
     }
 
     // Detail section verification
     private func verifyDetailSection(receiptIdVal: String, dateVal: String, clientIdVal: String?) {
-        let receiptDetailTableviewTable = transactDetails.receiptDetailTableviewTable
         let detailsSectionLabel = transactDetails.detailSection
         let receiptLabel = transactDetails.receiptIdLabel
         let dateLabel = transactDetails.dateLabel
-        let receiptID = receiptDetailTableviewTable.staticTexts[receiptIdVal]
-        let date = receiptDetailTableviewTable.staticTexts[dateVal]
+        let receiptID = transactDetails.receiptIdValue
+        let date = transactDetails.dateValue
 
         XCTAssertTrue(detailsSectionLabel.exists)
         XCTAssertTrue(receiptLabel.exists)
@@ -126,7 +124,7 @@ class TransactionDetailTests: BaseTests {
         if let clientIdVal = clientIdVal {
             let clientTransIDLabel = transactDetails.clientTransactionIdLabel
             XCTAssertTrue(clientTransIDLabel.exists)
-            let clientID = receiptDetailTableviewTable.staticTexts[clientIdVal]
+            let clientID = app.tables["receiptDetailTableView"].staticTexts[clientIdVal]
             XCTAssertTrue(clientID.exists)
             XCTAssertEqual(clientID.label, clientIdVal)
         }


### PR DESCRIPTION
-Fixed the test cases to use AccessibilityIDs.
-Merged the detail page test cases into ListReceipt file as requested by Shyang.
