### PR TITLE
DTSERWONE-821 - Handle HTTP 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 =========
+[1.0.0-beta18](https://github.com/hyperwallet/hyperwallet-ios-ui-sdk/releases/tag/1.0.0-beta18)
+-------------------
+- Handle HTTP 401
+
 [1.0.0-beta17](https://github.com/hyperwallet/hyperwallet-ios-ui-sdk/releases/tag/1.0.0-beta17)
 -------------------
 - iOS upgrade to version 13

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "hyperwallet/hyperwallet-ios-sdk" "1.0.0-beta16"
+github "hyperwallet/hyperwallet-ios-sdk" "1.0.0-beta18"
 github "hyperwallet/hyperwallet-ios-insight" "1.0.0-beta05"

--- a/Common/CurrencyFormatter.swift
+++ b/Common/CurrencyFormatter.swift
@@ -81,7 +81,10 @@ class CurrencyFormatterTests: XCTestCase {
             ("Vietnam Currency", "1000000", "VND", "1.000.000,00")
         ]
         cases.forEach {
-            let expected = $3.replacingOccurrences(of: "\u{200F}", with: "", options: NSString.CompareOptions.literal, range: nil)
+            let expected = $3.replacingOccurrences(of: "\u{200F}",
+                                                   with: "",
+                                                   options: NSString.CompareOptions.literal,
+                                                   range: nil)
             XCTAssertEqual(CurrencyFormatter.formatStringAmount($1, with: $2),
                            expected,
                            "\($0) \($2) test case - currency should be equal to \($3)")
@@ -148,7 +151,10 @@ class CurrencyFormatterTests: XCTestCase {
             ("Vietnam Currency", "1000000", "VND", "1.000.000,00")
         ]
         cases.forEach {
-            let expected = $3.replacingOccurrences(of: "\u{200F}", with: "", options: NSString.CompareOptions.literal, range: nil)
+            let expected = $3.replacingOccurrences(of: "\u{200F}",
+                                                   with: "",
+                                                   options: NSString.CompareOptions.literal,
+                                                   range: nil)
             let doubleAmount = NSString(string: $1).doubleValue
             XCTAssertEqual(CurrencyFormatter.formatDoubleAmount(doubleAmount, with: $2),
                            expected,

--- a/Common/Sources/Extensions/UIBarButtonItem.swift
+++ b/Common/Sources/Extensions/UIBarButtonItem.swift
@@ -22,6 +22,6 @@ import UIKit
 public extension UIBarButtonItem {
     /// Override the text of back button  
     static var back: UIBarButtonItem = {
-        UIBarButtonItem(title: "backBarButton".localized(), style: .plain, target: self, action: nil)
+        UIBarButtonItem(title: "backBarButton".localized(), style: .plain, target: UIBarButtonItem.self, action: nil)
     }()
 }

--- a/Common/Sources/Generics/GenericController.swift
+++ b/Common/Sources/Generics/GenericController.swift
@@ -178,7 +178,7 @@ private extension GenericController {
     func setupUISearchController() {
         searchController.searchResultsUpdater = self
         definesPresentationContext = true
-        searchController.dimsBackgroundDuringPresentation = false
+        searchController.obscuresBackgroundDuringPresentation = false
         setupSearchBarSize()
         searchController.delegate = self
         searchController.hidesNavigationBarDuringPresentation = false
@@ -232,11 +232,9 @@ private extension GenericController {
     func scrollToSelectedRow() {
         var selectedItemIndex: Int?
 
-        for index in items.indices {
-            if shouldMarkCellAction?(retrieveItems()[index]) ?? false {
-                selectedItemIndex = index
-                break
-            }
+        for index in items.indices where shouldMarkCellAction?(retrieveItems()[index]) ?? false {
+            selectedItemIndex = index
+            break
         }
 
         guard let indexToScrollTo = selectedItemIndex, indexToScrollTo < items.count else {

--- a/Common/Sources/Helper/CurrencyFormatter.swift
+++ b/Common/Sources/Helper/CurrencyFormatter.swift
@@ -52,7 +52,11 @@ public struct CurrencyFormatter {
             formatter.currencySymbol = ""
 
             if let amount = formatter.string(from: NSNumber(value: amount)) {
-                return amount.replacingOccurrences(of: "\u{200F}", with: "", options: NSString.CompareOptions.literal, range: nil).trimmingCharacters(in: .whitespaces)
+                return amount.replacingOccurrences(of: "\u{200F}",
+                                                   with: "",
+                                                   options: NSString.CompareOptions.literal,
+                                                   range: nil)
+                    .trimmingCharacters(in: .whitespaces)
             }
         }
         return "\(amount)"
@@ -92,7 +96,12 @@ public struct CurrencyFormatter {
             formatter.currencyCode = currencyCode
             formatter.locale = getLocaleIdentifer(for: currencyCode)
             formatter.currencySymbol = ""
-            return formatter.string(for: number)?.replacingOccurrences(of: "\u{200F}", with: "", options: NSString.CompareOptions.literal, range: nil).trimmingCharacters(in: .whitespaces) ?? amount
+            return formatter.string(for: number)?
+                .replacingOccurrences(of: "\u{200F}",
+                                      with: "",
+                                      options: NSString.CompareOptions.literal,
+                                      range: nil)
+                .trimmingCharacters(in: .whitespaces) ?? amount
         } else {
             return amount
         }

--- a/Common/Sources/Helper/Theme.swift
+++ b/Common/Sources/Helper/Theme.swift
@@ -158,7 +158,7 @@ public class Theme: NSObject {
     /// Representation of all customizable visual style property for `SpinnerView`.
     public struct SpinnerView {
         /// The `UIActivityIndicatorView` style
-        public static var activityIndicatorViewStyle = UIActivityIndicatorView.Style.whiteLarge
+        public static var activityIndicatorViewStyle = UIActivityIndicatorView.Style.large
         /// The `UIActivityIndicatorView` color
         public static var activityIndicatorViewColor = Theme.themeColor
         /// The background color

--- a/Common/Sources/HyperwalletFlowDelegate.swift
+++ b/Common/Sources/HyperwalletFlowDelegate.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 /// Flow complete protocol
-public protocol HyperwalletFlowDelegate: class {
+public protocol HyperwalletFlowDelegate: AnyObject {
     /// Protocol method to be called after flow completes
     func didFlowComplete(with response: Any)
 }

--- a/Common/Sources/Insights/HyperwalletInsights.swift
+++ b/Common/Sources/Insights/HyperwalletInsights.swift
@@ -21,7 +21,7 @@ import HyperwalletSDK
 import Insights
 
 /// Protocol for HyperwalletInsights
-public protocol HyperwalletInsightsProtocol: class {
+public protocol HyperwalletInsightsProtocol: AnyObject {
     /// Track Clicks
     ///
     /// - Parameters:

--- a/Common/Tests/Extensions/StringTests.swift
+++ b/Common/Tests/Extensions/StringTests.swift
@@ -81,8 +81,13 @@ class StringTests: XCTestCase {
                      ("Vietnam Currency", "1000000", "VND", "₫1.000.000,00")
         ]
         cases.forEach {
-            let expected = $3.replacingOccurrences(of: "\u{200F}", with: "", options: NSString.CompareOptions.literal, range: nil)
-                        XCTAssertEqual($1.formatToCurrency(with: $2), expected, "\($0) test case - currency should be equal to \($3)")
+            let expected = $3.replacingOccurrences(of: "\u{200F}",
+                                                   with: "",
+                                                   options: NSString.CompareOptions.literal,
+                                                   range: nil)
+                        XCTAssertEqual($1.formatToCurrency(with: $2),
+                                       expected,
+                                       "\($0) test case - currency should be equal to \($3)")
         }
     }
 }

--- a/HyperwalletUISDK.podspec
+++ b/HyperwalletUISDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                  = 'HyperwalletUISDK'
-    spec.version               = '1.0.0-beta17'
+    spec.version               = '1.0.0-beta18'
     spec.summary               = 'Hyperwallet UI SDK for iOS to integrate with Hyperwallet Platform'
     spec.homepage              = 'https://github.com/hyperwallet/hyperwallet-ios-ui-sdk'
     spec.license               = { :type => 'MIT', :file => 'LICENSE' }
@@ -35,7 +35,7 @@ Pod::Spec.new do |spec|
     spec.subspec "UserRepository" do |userRepository|
         userRepository.source_files = "UserRepository/Sources/**/*.{swift,h}"
     end
-    
+
     spec.subspec "BalanceRepository" do |balanceRepository|
         balanceRepository.source_files = "BalanceRepository/Sources/**/*.{swift,h}"
     end

--- a/HyperwalletUISDK.xcodeproj/project.pbxproj
+++ b/HyperwalletUISDK.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 		D4527B5A258CD22900B09019 /* BankAccountIndividualUpdateResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = FD6D1AF02583AE3C0019333E /* BankAccountIndividualUpdateResponse.json */; };
 		D4527B5D258CD3F500B09019 /* ListTransferMethodWireAccount.json in Resources */ = {isa = PBXBuildFile; fileRef = D4527B5C258CD3F500B09019 /* ListTransferMethodWireAccount.json */; };
 		D4527B5E258CD5EF00B09019 /* WireAccountUpdateResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = FDF1CF112588EF64005FB4D1 /* WireAccountUpdateResponse.json */; };
+		DB3B369428BE93DA00165220 /* JWTTokenRevolked.json in Resources */ = {isa = PBXBuildFile; fileRef = DB3B369328BE93DA00165220 /* JWTTokenRevolked.json */; };
 		DB4679852260380C00E1AF49 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4679842260380C00E1AF49 /* AppDelegate.swift */; };
 		DB4679872260380C00E1AF49 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4679862260380C00E1AF49 /* ViewController.swift */; };
 		DB46798A2260380C00E1AF49 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DB4679882260380C00E1AF49 /* Main.storyboard */; };
@@ -1025,6 +1026,7 @@
 		DB2587FB2261BFF100E6236B /* HyperwalletUISDKUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HyperwalletUISDKUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB2587FF2261BFF100E6236B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DB2EB66C22617A8500FBEB3D /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		DB3B369328BE93DA00165220 /* JWTTokenRevolked.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = JWTTokenRevolked.json; sourceTree = "<group>"; };
 		DB4679822260380C00E1AF49 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB4679842260380C00E1AF49 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DB4679862260380C00E1AF49 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -2438,6 +2440,7 @@
 				641324E32295764500512816 /* AuthenticationTokens */,
 				C358A9A9227267C000E5AE47 /* TransferMethod */,
 				DBFB61492261E84C00C4A8AA /* UnexpectedErrorResponse.json */,
+				DB3B369328BE93DA00165220 /* JWTTokenRevolked.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -3441,6 +3444,7 @@
 				DCF74268257E305600A5295A /* ListTransferMethodResponsePaperCheck.json in Resources */,
 				D4527B48258B6A8E00B09019 /* TransferMethodUpdateConfigurationFieldsPaperCheckResponse.json in Resources */,
 				98F63E6E2284AD370090101D /* PayPalAccountDuplicateResponse.json in Resources */,
+				DB3B369428BE93DA00165220 /* JWTTokenRevolked.json in Resources */,
 				DC49BF15257E06B600567832 /* TransferMethodPaperCheckResponse.json in Resources */,
 				41759420239716C600921392 /* TransferMethodConfigrationUSBankAccountResponseMask.json in Resources */,
 				98F3D757230C5C1000A8195F /* AvailableFundCAD.json in Resources */,

--- a/HyperwalletUISDK.xcodeproj/project.pbxproj
+++ b/HyperwalletUISDK.xcodeproj/project.pbxproj
@@ -3148,7 +3148,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1170;
+				LastUpgradeCheck = 1340;
 				ORGANIZATIONNAME = "Hyperwallet Systems";
 				TargetAttributes = {
 					073BB98122E63DB50053C24E = {
@@ -3645,7 +3645,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint autocorrect\n    swiftlint\n  fi\nfi\n";
+			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint --fix\n    swiftlint\n  fi\nfi\n";
 		};
 		4A012F5022D62EAA008C1D35 /* Swift Lint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3663,7 +3663,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint autocorrect\n    swiftlint\n  fi\nfi\n";
+			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint --fix\n    swiftlint\n  fi\nfi\n";
 		};
 		4A9A7BF922E85B390022E573 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3681,7 +3681,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint autocorrect\n    swiftlint\n  fi\nfi\n";
+			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint --fix\n    swiftlint\n  fi\nfi\n";
 		};
 		DB551F6322E132C000DD65C2 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3699,7 +3699,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint autocorrect\n    swiftlint\n  fi\nfi\n";
+			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint --fix\n    swiftlint\n  fi\nfi\n";
 		};
 		DB551F6422E132D900DD65C2 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3717,7 +3717,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint autocorrect\n    swiftlint\n  fi\nfi\n";
+			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint --fix\n    swiftlint\n  fi\nfi\n";
 		};
 		DBAF92B922CFCEF2004F197A /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3735,7 +3735,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint autocorrect\n    swiftlint\n  fi\nfi\n";
+			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint --fix\n    swiftlint\n  fi\nfi\n";
 		};
 		DBC199FC22E29D3E004447DD /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3753,7 +3753,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint autocorrect\n    swiftlint\n  fi\nfi\n";
+			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint --fix\n    swiftlint\n  fi\nfi\n";
 		};
 		DBC199FD22E29D4E004447DD /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3771,7 +3771,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint autocorrect\n    swiftlint\n  fi\nfi\n";
+			shellScript = "set -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint --fix\n    swiftlint\n  fi\nfi\n";
 		};
 		FD9509DD25EE31B300585046 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3789,7 +3789,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nset -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint autocorrect\n    swiftlint\n  fi\nfi\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nset -e\nset -x\nif [ -z \"$CI\" ]; then\n  if ! which swiftlint > /dev/null; then\n    echo \"warning: SwiftLint is not installed. To install run `brew install SwiftLint`\"\n  else\n    swiftlint --fix\n    swiftlint\n  fi\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -5155,7 +5155,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = UITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5183,7 +5183,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = UITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5212,7 +5212,7 @@
 				DEVELOPMENT_TEAM = 86FDS64Z83;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Demo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5243,7 +5243,7 @@
 				DEVELOPMENT_TEAM = 86FDS64Z83;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Demo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5622,6 +5622,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -5672,7 +5673,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = UITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5701,7 +5702,7 @@
 				DEVELOPMENT_TEAM = 86FDS64Z83;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Demo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6086,6 +6087,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -6154,6 +6156,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -6194,7 +6197,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -6230,7 +6233,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -6265,7 +6268,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;

--- a/HyperwalletUISDK.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/HyperwalletUISDK.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1170"
+   LastUpgradeVersion = "1340"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/HyperwalletUISDK.xcodeproj/xcshareddata/xcschemes/HyperwalletUISDK.xcscheme
+++ b/HyperwalletUISDK.xcodeproj/xcshareddata/xcschemes/HyperwalletUISDK.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1170"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Adding one or more of these frameworks allows users to explore the particular fu
 ### Carthage
 Specify it in your Cartfile:
 ```ogdl
-github "hyperwallet/hyperwallet-ios-ui-sdk" "1.0.0-beta17"
+github "hyperwallet/hyperwallet-ios-ui-sdk" "1.0.0-beta18"
 ```
 Add desired modules using the `Linked Frameworks and Libraries` option to make them available in the app.
 Use `import <module-name>` to add the dependency within a file
@@ -42,13 +42,13 @@ Use `import <module-name>` to add the dependency within a file
 ### CocoaPods
 - Install a specific framework (install one or more frameworks based on your requirement)
 ```ruby
-pod "HyperwalletUISDK/TransferMethod", "1.0.0-beta17"
-pod "HyperwalletUISDK/Transfer", "1.0.0-beta17"
-pod "HyperwalletUISDK/Receipt", "1.0.0-beta17"
+pod "HyperwalletUISDK/TransferMethod", "1.0.0-beta18"
+pod "HyperwalletUISDK/Transfer", "1.0.0-beta18"
+pod "HyperwalletUISDK/Receipt", "1.0.0-beta18"
 ```
 - To install all available modules (TransferMethod, Transfer, Receipt)
 ```ruby
-pod 'HyperwalletUISDK', '~> 1.0.0-beta17'
+pod 'HyperwalletUISDK', '~> 1.0.0-beta18'
 ```
 Use `import HyperwalletUISDK` to add the dependency within a file.
 

--- a/Receipt/Sources/ListReceiptPresenter.swift
+++ b/Receipt/Sources/ListReceiptPresenter.swift
@@ -23,7 +23,7 @@ import ReceiptRepository
 import TransferMethodRepository
 #endif
 
-protocol ListReceiptView: class {
+protocol ListReceiptView: AnyObject {
     func hideLoading()
     func reloadData()
     func showError(_ error: HyperwalletErrorType,

--- a/Receipt/Tests/ListReceiptPresenterTests.swift
+++ b/Receipt/Tests/ListReceiptPresenterTests.swift
@@ -285,7 +285,7 @@ class ListReceiptPresenterTests: XCTestCase {
                                      _ error: NSError? = nil,
                                      _ prepaidCardToken: String? = nil) -> StubRequest {
         let response = HyperwalletTestHelper.setUpMockedResponse(payload: payload, error: error)
-        let receiptUrl = prepaidCardToken == nil ? "/receipts?":"/prepaid-cards/\(prepaidCardToken!)/receipts?"
+        let receiptUrl = prepaidCardToken == nil ? "/receipts?" : "/prepaid-cards/\(prepaidCardToken!)/receipts?"
         let url = String(format: "%@%@", HyperwalletTestHelper.userRestURL, receiptUrl)
         return HyperwalletTestHelper.buildGetRequestRegexMatcher(pattern: url, response)
     }

--- a/ReceiptRepository/Tests/Helper/ReceiptRequestHelper.swift
+++ b/ReceiptRepository/Tests/Helper/ReceiptRequestHelper.swift
@@ -25,7 +25,7 @@ class ReceiptRequestHelper {
                              _ error: NSError? = nil,
                              _ prepaidCardToken: String? = nil) -> StubRequest {
         let response = HyperwalletTestHelper.setUpMockedResponse(payload: payload, error: error)
-        let receiptUrl = prepaidCardToken == nil ? "/receipts?":"/prepaid-cards/\(prepaidCardToken!)/receipts?"
+        let receiptUrl = prepaidCardToken == nil ? "/receipts?" : "/prepaid-cards/\(prepaidCardToken!)/receipts?"
         let url = String(format: "%@%@", HyperwalletTestHelper.userRestURL, receiptUrl)
         return HyperwalletTestHelper.buildGetRequestRegexMatcher(pattern: url, response)
     }

--- a/Transfer/Sources/CreateTransferPresenter.swift
+++ b/Transfer/Sources/CreateTransferPresenter.swift
@@ -25,7 +25,7 @@ import UserRepository
 #endif
 import HyperwalletSDK
 
-protocol CreateTransferView: class {
+protocol CreateTransferView: AnyObject {
     func hideLoading()
     func notifyTransferCreated(_ transfer: HyperwalletTransfer)
     func reloadData()

--- a/Transfer/Sources/CreateTransferSectionData.swift
+++ b/Transfer/Sources/CreateTransferSectionData.swift
@@ -26,7 +26,7 @@ enum CreateTransferSectionHeader: String, CaseIterable {
     case button, destination, notes, transferAll, amount, source
 }
 
-protocol CreateTransferSectionData: class {
+protocol CreateTransferSectionData: AnyObject {
     var cellIdentifiers: [String] { get }
     var createTransferSectionHeader: CreateTransferSectionHeader { get }
     var errorMessage: String? { get set }

--- a/Transfer/Sources/ListTransferDestinationPresenter.swift
+++ b/Transfer/Sources/ListTransferDestinationPresenter.swift
@@ -21,7 +21,7 @@ import HyperwalletSDK
 import TransferMethodRepository
 #endif
 
-protocol ListTransferDestinationView: class {
+protocol ListTransferDestinationView: AnyObject {
     func hideLoading()
     func showError(_ error: HyperwalletErrorType,
                    pageName: String,

--- a/Transfer/Sources/ScheduleTransferPresenter.swift
+++ b/Transfer/Sources/ScheduleTransferPresenter.swift
@@ -23,7 +23,7 @@ import TransferRepository
 #endif
 import HyperwalletSDK
 
-protocol ScheduleTransferView: class {
+protocol ScheduleTransferView: AnyObject {
     func showLoading()
     func hideLoading()
     func showConfirmation(handler: @escaping (() -> Void))

--- a/TransferMethod/Sources/AddTransferMethodPresenter.swift
+++ b/TransferMethod/Sources/AddTransferMethodPresenter.swift
@@ -22,7 +22,7 @@ import Common
 import TransferMethodRepository
 #endif
 
-protocol AddTransferMethodView: class {
+protocol AddTransferMethodView: AnyObject {
     func fieldValues() -> [(name: String, value: String)]
     func dismissProcessing(handler: @escaping () -> Void)
     func hideLoading()

--- a/TransferMethod/Sources/ListTransferMethodPresenter.swift
+++ b/TransferMethod/Sources/ListTransferMethodPresenter.swift
@@ -22,7 +22,7 @@ import Common
 import TransferMethodRepository
 #endif
 
-protocol ListTransferMethodView: class {
+protocol ListTransferMethodView: AnyObject {
     func showLoading()
     func hideLoading()
     func showProcessing()

--- a/TransferMethod/Sources/SelectTransferMethodTypeController.swift
+++ b/TransferMethod/Sources/SelectTransferMethodTypeController.swift
@@ -100,7 +100,7 @@ extension SelectTransferMethodTypeController {
     }
     /// Returns tableview section count
     override public func numberOfSections(in tableView: UITableView) -> Int {
-        return presenter.countryCurrencySectionData.isNotEmpty ? 1:0
+        return presenter.countryCurrencySectionData.isNotEmpty ? 1 : 0
     }
     /// Display transfer methods
     override public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/TransferMethod/Sources/SelectTransferMethodTypePresenter.swift
+++ b/TransferMethod/Sources/SelectTransferMethodTypePresenter.swift
@@ -24,7 +24,7 @@ import TransferMethodRepository
 import UserRepository
 #endif
 
-protocol SelectTransferMethodTypeView: class {
+protocol SelectTransferMethodTypeView: AnyObject {
     typealias SelectItemHandler = (_ value: GenericCellConfiguration) -> Void
     typealias MarkCellHandler = (_ value: GenericCellConfiguration) -> Bool
     typealias FilterContentHandler = ((_ items: [GenericCellConfiguration],

--- a/TransferMethod/Sources/UpdateTransferMethodPresenter.swift
+++ b/TransferMethod/Sources/UpdateTransferMethodPresenter.swift
@@ -22,7 +22,7 @@ import Common
 import TransferMethodRepository
 #endif
 
-protocol UpdateTransferMethodView: class {
+protocol UpdateTransferMethodView: AnyObject {
     func fieldValues() -> [(name: String, value: String)]
     func dismissProcessing(handler: @escaping () -> Void)
     func hideLoading()

--- a/UITests/BaseTests/BaseTest.swift
+++ b/UITests/BaseTests/BaseTest.swift
@@ -72,7 +72,12 @@ class BaseTests: XCTestCase {
                                   method: HTTPMethod.get)
 
         // speed up UI
-        UIApplication.shared.keyWindow?.layer.speed = 100
+        let keyWindow = UIApplication.shared.connectedScenes
+                .filter({$0.activationState == .foregroundActive})
+                .compactMap({$0 as? UIWindowScene})
+                .first?.windows
+                .filter({$0.isKeyWindow}).first
+        keyWindow?.layer.speed = 100
         UIView.setAnimationsEnabled(false)
     }
 

--- a/UITests/Receipts/ListReceiptTests.swift
+++ b/UITests/Receipts/ListReceiptTests.swift
@@ -282,14 +282,14 @@ class ListReceiptTests: BaseTests {
 
         openReceiptsListScreen()
 
-        verifyCurrencyAndCurrencyCode("Bank Account", "-"+CurrencyCode.USD.1 + "0.00", CurrencyCode.USD.0, at: 0)
+        verifyCurrencyAndCurrencyCode("Bank Account", "-" + CurrencyCode.USD.1 + "0.00", CurrencyCode.USD.0, at: 0)
         verifyCurrencyAndCurrencyCode("Payment", CurrencyCode.USD.1 + "1,000,000.99", CurrencyCode.USD.0, at: 1)
         verifyCurrencyAndCurrencyCode("Bank Account",
-                                      "-"+CurrencyCode.USD.1 + "1,000,000,000.99",
+                                      "-" + CurrencyCode.USD.1 + "1,000,000,000.99",
                                       CurrencyCode.USD.0,
                                       at: 2)
         verifyCurrencyAndCurrencyCode("Bank Account",
-                                      "-"+CurrencyCode.USD.1 + "10,000,000,000,000,000,000.00",
+                                      "-" + CurrencyCode.USD.1 + "10,000,000,000,000,000,000.00",
                                       CurrencyCode.USD.0,
                                       at: 3)
         verifyCellExists("Debit Card", "2019-05-01T17:35:20", "¥1,000,000,000", "JPY", at: 11)
@@ -317,14 +317,14 @@ class ListReceiptTests: BaseTests {
         openReceiptsListScreen()
 
         // add back asssertions
-        verifyCurrencyAndCurrencyCode("Bank Account", "-"+CurrencyCode.USD.1 + "0.00", CurrencyCode.USD.0, at: 0)
+        verifyCurrencyAndCurrencyCode("Bank Account", "-" + CurrencyCode.USD.1 + "0.00", CurrencyCode.USD.0, at: 0)
         verifyCurrencyAndCurrencyCode("Payment", CurrencyCode.USD.1 + "1,000,000.99", CurrencyCode.USD.0, at: 1)
         verifyCurrencyAndCurrencyCode("Bank Account",
-                                      "-"+CurrencyCode.USD.1 + "1,000,000,000.99",
+                                      "-" + CurrencyCode.USD.1 + "1,000,000,000.99",
                                       CurrencyCode.USD.0,
                                       at: 2)
         verifyCurrencyAndCurrencyCode("Bank Account",
-                                      "-"+CurrencyCode.USD.1 + "10,000,000,000,000,000,000.00",
+                                      "-" + CurrencyCode.USD.1 + "10,000,000,000,000,000,000.00",
                                       CurrencyCode.USD.0,
                                       at: 3)
         verifyCurrencyAndCurrencyCode("Payment", CurrencyCode.CAD.1 + "1,000,000,000.99", CurrencyCode.CAD.0, at: 4)

--- a/UITests/Responses/JWTTokenRevolked.json
+++ b/UITests/Responses/JWTTokenRevolked.json
@@ -1,0 +1,8 @@
+{
+   "errors":[
+      {
+         "message":"JWT expired",
+         "code":"JWT_EXPIRED"
+      }
+   ]
+}

--- a/UITests/TransferFunds/TransferUserFundsTest.swift
+++ b/UITests/TransferFunds/TransferUserFundsTest.swift
@@ -118,8 +118,12 @@ class TransferUserFundsTest: BaseTests {
         transferFunds.verifyTransferFundsTitle()
         
         waitForExistence(app.alerts["Unexpected Error"])
-        XCUIApplication().alerts["Unexpected Error"]
-            .scrollViews.otherElements.buttons["Done"].tap()
+        XCUIApplication()
+            .alerts["Unexpected Error"]
+            .scrollViews
+            .otherElements
+            .buttons["Done"]
+            .tap()
         waitForNonExistence(spinner)
         XCTAssertTrue(transferFundMenu.exists)
     }

--- a/UITests/TransferMethod/AddTransferMethodBankAccountIndividualTests.swift
+++ b/UITests/TransferMethod/AddTransferMethodBankAccountIndividualTests.swift
@@ -153,6 +153,25 @@ class AddTransferMethodBankAccountIndividualTests: BaseTests {
         XCTAssert(otherElements
             .containing(NSPredicate(format: "label CONTAINS %@", invalidRoutingNumberError)).count == 1)
     }
+    
+    func testAddTransferMethod_rest_unauthenticatedError() {
+        mockServer.setupStubError(url: "/rest/v3/users/usr-token/bank-accounts",
+                                  filename: "JWTTokenRevolked",
+                                  method: HTTPMethod.post,
+                                  statusCode: 401)
+        
+        waitForExistence(addTransferMethod.branchIdInput)
+        
+        addTransferMethod.setBranchId("021000022")
+        addTransferMethod.setBankAccountId("12345")
+        addTransferMethod.selectAccountType("CHECKING")
+
+        addTransferMethod.clickCreateTransferMethodButton()
+        waitForNonExistence(spinner)
+        
+        
+        XCTAssertEqual(app.alerts.element.label, "Authentication Error")
+    }
 
     func testAddTransferMethod_createBankAccountValidResponse() {
         mockServer.setupStub(url: "/rest/v3/users/usr-token/bank-accounts",

--- a/UITests/TransferMethod/SelectTransferMethodTypeTests.swift
+++ b/UITests/TransferMethod/SelectTransferMethodTypeTests.swift
@@ -85,6 +85,21 @@ class SelectTransferMethodTypeTests: BaseTests {
         app.tables["selectTransferMethodTypeTable"].staticTexts.element(matching: bankAccount).tap()
         XCTAssert(app.navigationBars["Bank Account"].exists)
     }
+    
+    func testSelectTransferMethod_graphQL_unauthenticatedError() {
+        selectTransferMethodType.selectCountry(country: "United States")
+        mockServer.setupStubError(url: "/graphql",
+                                  filename: "JWTTokenRevolked",
+                                  method: HTTPMethod.post,
+                                  statusCode: 401)
+        
+
+
+        app.tables["selectTransferMethodTypeTable"].staticTexts.element(matching: bankAccount).tap()
+        waitForNonExistence(app.activityIndicators["activityIndicator"])
+        
+        XCTAssertEqual(app.alerts.element.label, "Authentication Error")
+    }
 
     func testSelectTransferMethod_clickBankCardOpensAddTransferMethodUi () {
         selectTransferMethodType.selectCountry(country: "United States")


### PR DESCRIPTION
# Sumary
Update the core SDK to handle HTTP 401

## Changes
- Add support to handle HTTP 401 
- Prepare code to 1.0.0-beta18
- Increase min version to  iOS 13
- Addressed lint check errors `swiftlint lint --strict --reporter json`
- Addressed IOS 13 deprecated calls:
     - Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead
     - whiteLarge' was deprecated in iOS 13.0: renamed to 'UIActivityIndicatorView.Style.large
     - 'self' refers to the method 'UIBarButtonItem.self', which may be unexpected
     - `where` clauses are preferred over a single `if` inside a `for`.

## Required
- [ ]  https://github.com/hyperwallet/hyperwallet-ios-sdk/pull/132

## Unit test result 
<img width="1575" alt="Screen Shot 2022-08-30 at 10 51 30 AM" src="https://user-images.githubusercontent.com/107439697/187508401-9ff7b458-1dff-495e-81c8-2a756e0d03fb.png">


## Ui Test 
The Server return HTTP 401

### GraphQL
https://user-images.githubusercontent.com/107439697/187521166-9adb71c9-da4c-46ff-ac39-ca5cf04ca82e.mp4

### Rest
https://user-images.githubusercontent.com/107439697/187521217-31c4fb06-7e06-45b9-916d-a92b753e133b.mp4






