### PR TITLE
DTSERWONE-887 - Generate documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,6 @@ on:
       - support/SDK-V3
       - feature/**
       - bugfix/**
-  pull_request:
-    branches:
-      - master
-      - support/SDK-V3
-      - feature/**
-      - bugfix/**
 jobs:
   tests:
     name: Tests
@@ -67,7 +61,8 @@ jobs:
       - name: Code Coverage [Build report]
         if: matrix.code_coverage
         run: |
-          export PATH="/usr/local/opt/llvm/bin:$PATH"
+          brew install llvm
+          export PATH="$(brew --prefix llvm)/bin:$PATH"
           llvm-cov report \
           --use-color \
           --instr-profile=$(find ./output -name "*.profdata") \
@@ -86,7 +81,7 @@ jobs:
       - name: Code Coverage [Export report to lcov format]
         if: matrix.code_coverage
         run: |
-          export PATH="/usr/local/opt/llvm/bin:$PATH"
+          export PATH="$(brew --prefix llvm)/bin:$PATH"
           mkdir coverage
           llvm-cov export \
           --format=lcov > ./coverage/lcov.info \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependency
-        run: brew install
+        run: brew install sourcekitten
 
       - name: Extract comment docs
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,57 @@
+name: Update Documentation
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - support/SDK-V3
+      - feature/**
+      - bugfix/**
+
+jobs:
+  documentation:
+    name: Documentation
+    strategy:
+      matrix:
+        include:
+          - os: macos-12
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Generate documentation
+        run: |
+          mkdir -p TempJson
+            sourcekitten doc --module-name Transfer > TempJson/Transfer.json
+            sourcekitten doc --module-name UserRepository > TempJson/UserRepository.json
+            sourcekitten doc --module-name TransferRepository > TempJson/TransferRepository.json
+            sourcekitten doc --module-name TransferMethodRepository > TempJson/TransferMethodRepository.json
+            sourcekitten doc --module-name TransferMethod > TempJson/TransferMethod.json
+            sourcekitten doc --module-name Common > TempJson/Common.json
+            sourcekitten doc --module-name ReceiptRepository > TempJson/ReceiptRepository.json
+            sourcekitten doc --module-name Receipt > TempJson/Receipt.json
+          jazzy \
+            --author Hyperwallet Systems Inc \
+            --author_url https://www.hyperwallet.com/ \
+            --github_url https://github.com/hyperwallet/hyperwallet-ios-ui-sdk \
+            --module HyperwalletUISDK \
+            --module-version 0.0.1 \
+            --hide-documentation-coverage \
+            --readme README.md \
+            --skip-undocumented \
+            --use-safe-filenames \
+            --min-acl public \
+            --clean \
+            --title HyperwalletUISDK \
+            --sourcekitten-sourcefile TempJson/Transfer.json,TempJson/UserRepository.json,TempJson/TransferRepository.json,TempJson/TransferMethodRepository.json,TempJson/TransferMethod.json,TempJson/Common.json,TempJson/ReceiptRepository.json,TempJson/Receipt.json \
+            --no-hide-documentation-coverage \
+            --theme fullwidth \
+            --output ./docs \
+            --documentation=./*.md
+
+      - name: Publish on GitHub Pages
+        uses: ftnext/action-push-ghpages@v1.0.0
+        with:
+          build_dir: docs
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,9 +16,35 @@ jobs:
       matrix:
         include:
           - os: macos-12
+            fastlane_task: 'unit_tests'
+            xcode_version: 13.4
+            code_coverage: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '${{ matrix.xcode_version }}'
+
+      - name: Carthage [Setup cache]
+        uses: actions/cache@v3
+        with:
+          path: Carthage
+          key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+
+      - name: Carthage [Install dependencies]
+        run: carthage bootstrap
+          --platform ios
+          --cache-builds
+          --use-xcframeworks
+          --no-use-binaries
+
+      - name: Run ${{ matrix.task_title }}
+        run: fastlane ${{ matrix.fastlane_task }}
 
       - name: Install dependency
         run: brew install sourcekitten

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Generate documentation
+      - name: Install dependency
+        run: brew install
+
+      - name: Extract comment docs
         run: |
           mkdir -p TempJson
             sourcekitten doc --module-name Transfer > TempJson/Transfer.json
@@ -31,6 +34,9 @@ jobs:
             sourcekitten doc --module-name Common > TempJson/Common.json
             sourcekitten doc --module-name ReceiptRepository > TempJson/ReceiptRepository.json
             sourcekitten doc --module-name Receipt > TempJson/Receipt.json
+
+      - name: Generate documentation
+        run: |
           jazzy \
             --author Hyperwallet Systems Inc \
             --author_url https://www.hyperwallet.com/ \


### PR DESCRIPTION
Update iOS Core Api Documentation by Github Action

## Changes
- Push the updated documentation to gh-pages branch
- Trigger GitHub Action only on merging PR on master
- Install LLVM to fix the generation of the code coverage report
- Remove the Makefile, all instructions was migrated to Github action for clarity. 


## Test
### Fix build and generate documentation by Github Action
https://github.com/hyperwallet/hyperwallet-ios-ui-sdk/actions
<img width="1484" alt="Screen Shot 2022-11-18 at 2 05 45 AM" src="https://user-images.githubusercontent.com/107439697/202677054-a540ac70-40a8-4103-aa57-197d48c97723.png">

### Update documentation branch via Github Action
<img width="1488" alt="Screen Shot 2022-11-18 at 2 06 21 AM" src="https://user-images.githubusercontent.com/107439697/202677474-b249fb9c-326e-4dd0-abc1-9ba54e621978.png">

### Updated documentation
<img width="1486" alt="Screen Shot 2022-11-18 at 2 06 02 AM" src="https://user-images.githubusercontent.com/107439697/202677534-f45b4d0e-d930-4b88-8589-a3ded0eae4c0.png">

