### PR TITLE
DTPOMERSER-84 - App cannot authenticate users into the app - Authentication token retrieval error

### DIFF
--- a/Common/Sources/HyperwalletUI.swift
+++ b/Common/Sources/HyperwalletUI.swift
@@ -69,6 +69,7 @@ public final class HyperwalletUI: NSObject {
             }
             
             instance = HyperwalletUI()
+            completion(nil)
         })
     }
 

--- a/Common/Sources/HyperwalletUI.swift
+++ b/Common/Sources/HyperwalletUI.swift
@@ -74,14 +74,14 @@ public final class HyperwalletUI: NSObject {
         }
     }
 
-    private override init() {
-        // Register custom fonts
-        UIFont.register("icomoon", type: "ttf")
-    }
-
     private convenience init(_ provider: HyperwalletAuthenticationTokenProvider) {
         self.init()
         Hyperwallet.setup(provider)
         HyperwalletInsights.setup()
+    }
+
+    private override init() {
+        // Register custom fonts
+        UIFont.register("icomoon", type: "ttf")
     }
 }

--- a/Common/Sources/HyperwalletUI.swift
+++ b/Common/Sources/HyperwalletUI.swift
@@ -63,24 +63,25 @@ public final class HyperwalletUI: NSObject {
         }
         
         Hyperwallet.setup(provider)
-        HyperwalletInsights.setup(completion: { error in
-            if let error = error {
-                completion(error);
+        Hyperwallet.shared.getConfiguration { configuration, error in
+            guard let configuration = configuration else {
+                completion(error)
+                return
             }
-            
-            instance = HyperwalletUI()
+
+            HyperwalletInsights.setup(configuration)
             completion(nil)
-        })
+        }
+    }
+
+    private override init() {
+        // Register custom fonts
+        UIFont.register("icomoon", type: "ttf")
     }
 
     private convenience init(_ provider: HyperwalletAuthenticationTokenProvider) {
         self.init()
         Hyperwallet.setup(provider)
         HyperwalletInsights.setup()
-    }
-    
-    private override init() {
-        // Register custom fonts
-        UIFont.register("icomoon", type: "ttf")
     }
 }

--- a/Common/Sources/HyperwalletUI.swift
+++ b/Common/Sources/HyperwalletUI.swift
@@ -45,7 +45,9 @@ public final class HyperwalletUI: NSObject {
     /// - Parameter provider: a provider of Hyperwallet authentication tokens.
     public class func setup(_ provider: HyperwalletAuthenticationTokenProvider) {
         if instance == nil {
-            instance = HyperwalletUI(provider)
+            Hyperwallet.setup(provider)
+            HyperwalletInsights.setup()
+            instance = HyperwalletUI()
         }
     }
     
@@ -74,13 +76,7 @@ public final class HyperwalletUI: NSObject {
         }
     }
 
-    private convenience init(_ provider: HyperwalletAuthenticationTokenProvider) {
-        self.init()
-        Hyperwallet.setup(provider)
-        HyperwalletInsights.setup()
-    }
-
-    private override init() {
+    override private init() {
         // Register custom fonts
         UIFont.register("icomoon", type: "ttf")
     }

--- a/Common/Sources/HyperwalletUI.swift
+++ b/Common/Sources/HyperwalletUI.swift
@@ -48,11 +48,38 @@ public final class HyperwalletUI: NSObject {
             instance = HyperwalletUI(provider)
         }
     }
+    
+    /// Creates a new instance of the Hyperwallet UI SDK interface object. If a previously created instance exists,
+    /// it will be replaced.
+    ///
+    /// - Parameters:
+    ///   - provider: a provider of Hyperwallet authentication tokens.
+    ///   - completion: the callback handler to indicate the initialization status
+    public class func setup(_ provider: HyperwalletAuthenticationTokenProvider,
+                            completion: @escaping (HyperwalletErrorType?) -> Void) {
+        if instance != nil {
+            completion(nil)
+            return
+        }
+        
+        Hyperwallet.setup(provider)
+        HyperwalletInsights.setup(completion: { error in
+            if let error = error {
+                completion(error);
+            }
+            
+            instance = HyperwalletUI()
+        })
+    }
 
-    private init(_ provider: HyperwalletAuthenticationTokenProvider) {
-        // Register custom fonts
-        UIFont.register("icomoon", type: "ttf")
+    private convenience init(_ provider: HyperwalletAuthenticationTokenProvider) {
+        self.init()
         Hyperwallet.setup(provider)
         HyperwalletInsights.setup()
+    }
+    
+    private override init() {
+        // Register custom fonts
+        UIFont.register("icomoon", type: "ttf")
     }
 }

--- a/Common/Sources/Insights/HyperwalletInsights.swift
+++ b/Common/Sources/Insights/HyperwalletInsights.swift
@@ -61,6 +61,10 @@ public class HyperwalletInsights: HyperwalletInsightsProtocol {
     private init() {
         loadConfigurationAndInitializeInsights(completion: { _ in })
     }
+    
+    private init(_ configuration: Configuration) {
+        initializeInsights(configuration: configuration)
+    }
 
     /// Clears Insights SDK instance.
     public static func clearInstance() {
@@ -73,6 +77,30 @@ public class HyperwalletInsights: HyperwalletInsightsProtocol {
         if instance == nil {
             instance = HyperwalletInsights()
         }
+    }
+    
+    static func setup(_ configuration: Configuration) {
+        instance = HyperwalletInsights(configuration)
+    }
+    
+    /// Set up HyperwalletInsights
+    /// - Parameter completion: the callback handler to indicate the initialization status
+    static func setup(completion: @escaping (HyperwalletErrorType?) -> Void) {
+        if let instance = instance {
+            completion(nil)
+            return
+        }
+        
+        Hyperwallet.shared.getConfiguration { configuration, error in
+            guard let configuration = configuration else {
+                completion(error)
+                return
+            }
+            
+            instance = HyperwalletInsights(configuration)
+            completion(nil)
+        }
+        
     }
 
     /// Track Clicks

--- a/Common/Sources/Insights/HyperwalletInsights.swift
+++ b/Common/Sources/Insights/HyperwalletInsights.swift
@@ -51,6 +51,7 @@ public protocol HyperwalletInsightsProtocol: AnyObject {
 /// It contains methods to call Insights for various actions performed by the user
 public class HyperwalletInsights: HyperwalletInsightsProtocol {
     private static var instance: HyperwalletInsights?
+    private var configuration: Configuration?
     var insights: InsightsProtocol?
 
     /// Returns the previously initialized instance of the HyperwalletInsights interface object
@@ -63,6 +64,7 @@ public class HyperwalletInsights: HyperwalletInsightsProtocol {
     }
     
     private init(_ configuration: Configuration) {
+        self.configuration = configuration
         initializeInsights(configuration: configuration)
     }
 
@@ -81,26 +83,6 @@ public class HyperwalletInsights: HyperwalletInsightsProtocol {
     
     static func setup(_ configuration: Configuration) {
         instance = HyperwalletInsights(configuration)
-    }
-    
-    /// Set up HyperwalletInsights
-    /// - Parameter completion: the callback handler to indicate the initialization status
-    static func setup(completion: @escaping (HyperwalletErrorType?) -> Void) {
-        if let instance = instance {
-            completion(nil)
-            return
-        }
-        
-        Hyperwallet.shared.getConfiguration { configuration, error in
-            guard let configuration = configuration else {
-                completion(error)
-                return
-            }
-            
-            instance = HyperwalletInsights(configuration)
-            completion(nil)
-        }
-        
     }
 
     /// Track Clicks
@@ -179,6 +161,11 @@ public class HyperwalletInsights: HyperwalletInsightsProtocol {
     }
 
     private func loadConfiguration(completion: @escaping(Configuration?) -> Void) {
+        if configuration != nil {
+            completion(configuration)
+            return
+        }
+        
         // Fetch configuration again
         Hyperwallet.shared.getConfiguration { configuration, _ in
             if let configuration = configuration {


### PR DESCRIPTION
[DTPOMERSER-84 ](https://paypal.atlassian.net/browse/DTPOMERSER-84) App cannot authenticate users into the app - Authentication token retrieval error

### Issue
- The current current Hyperwallet UI SDK is causing duplicate call to get the configuration due the silence initialization of the  Insight dependency. The SDK invoker will receive HTTP 401 when a duplicate call is performed to get configuration.

### Proposal solution
- Introduce a new constructor that returns completion handler to indicate the SDK initialization status then who is invoking the UI SDK can handle the initialization gracefully. 

### Changes
- Introduce a new setup that will perform completion ha…ndler when all UI SDK is initialied