### PR TITLE
Bugfix/LI-97987 Swifter SDK Embeds Trojan CDN - Polyfill.io (Supply Chain Attack)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
             fastlane_task: 'unit_tests'
             xcode_version: 16.2
             code_coverage: true
+            target_device: 'iPhone 16 Pro'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -46,6 +47,10 @@ jobs:
 
       - name: List devices
         run: xcrun simctl list devices
+
+
+      - name: List simulators
+        run: xcrun simctl boot "${{ matrix.target_device }}"
 
       - name: Run ${{ matrix.task_title }}
         run: fastlane ${{ matrix.fastlane_task }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
             fastlane_task: 'unit_tests'
             xcode_version: 16.2
             code_coverage: true
-            target_device: 'iPhone 16 Pro'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -30,19 +29,13 @@ jobs:
         with:
           xcode-version: '${{ matrix.xcode_version }}'
 
-      - name: List devices
-        run: xcrun simctl list devices
-
-      - name: Start simulator
-        run: xcrun simctl boot "${{ matrix.target_device }}"
-
-#      - name: Carthage [Setup cache]
-#        uses: actions/cache@v3
-#        with:
-#          path: Carthage
-#          key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
-#          restore-keys: |
-#            ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+      - name: Carthage [Setup cache]
+        uses: actions/cache@v3
+        with:
+          path: Carthage
+          key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
 
       - name: Carthage [Install dependencies]
         run: carthage bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
           --use-xcframeworks
           --no-use-binaries
 
+      - name: List devices
+        run: xcrun simctl list devices
+
       - name: Run ${{ matrix.task_title }}
         run: fastlane ${{ matrix.fastlane_task }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,19 @@ jobs:
         with:
           xcode-version: '${{ matrix.xcode_version }}'
 
-      - name: Carthage [Setup cache]
-        uses: actions/cache@v3
-        with:
-          path: Carthage
-          key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+      - name: List devices
+        run: xcrun simctl list devices
+
+      - name: Start simulator
+        run: xcrun simctl boot "${{ matrix.target_device }}"
+
+#      - name: Carthage [Setup cache]
+#        uses: actions/cache@v3
+#        with:
+#          path: Carthage
+#          key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+#          restore-keys: |
+#            ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
 
       - name: Carthage [Install dependencies]
         run: carthage bootstrap
@@ -44,13 +50,6 @@ jobs:
           --cache-builds
           --use-xcframeworks
           --no-use-binaries
-
-      - name: List devices
-        run: xcrun simctl list devices
-
-
-      - name: List simulators
-        run: xcrun simctl boot "${{ matrix.target_device }}"
 
       - name: Run ${{ matrix.task_title }}
         run: fastlane ${{ matrix.fastlane_task }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 Changelog
 =========
-[1.0.2](https://github.com/hyperwallet/hyperwallet-ios-ui-sdk/releases/tag/1.0.0-beta21)
+[1.0.3](https://github.com/hyperwallet/hyperwallet-ios-ui-sdk/releases/tag/1.0.3)
+-------------------
+- Replace dependecy Swifter by Ambassador
+
+[1.0.2](https://github.com/hyperwallet/hyperwallet-ios-ui-sdk/releases/tag/1.0.2)
 -------------------
 - iOS 18 Navigation Bar Display Issue Resolved it
 
-[1.0.1](https://github.com/hyperwallet/hyperwallet-ios-ui-sdk/releases/tag/1.0.0-beta21)
+[1.0.1](https://github.com/hyperwallet/hyperwallet-ios-ui-sdk/releases/tag/1.0.1)
 -------------------
 - Automatically select the default currency code based on the country's configuration
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,0 @@
-github "hyperwallet/hyperwallet-ios-sdk" "1.0.1"
-github "hyperwallet/hyperwallet-ios-insight" "1.0.0-beta08"

--- a/Cartfile 
+++ b/Cartfile 
@@ -1,0 +1,2 @@
+github "hyperwallet/hyperwallet-ios-sdk" "1.0.1"
+github "hyperwallet/hyperwallet-ios-insight" "1.0.0-beta08"

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,3 @@
 github "JanGorman/Hippolyte" "1.4.1"
-github "httpswift/swifter" "1.5.0"
+github "envoy/Ambassador" ~> 4.0
+github "envoy/Embassy" ~> 4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,3 @@
 github "JanGorman/Hippolyte" "1.4.1"
-github "httpswift/swifter" "1.5.0"
-github "hyperwallet/hyperwallet-ios-insight" "1.0.0-beta08"
-github "hyperwallet/hyperwallet-ios-sdk" "1.0.1"
+github "envoy/Ambassador" "v4.0.5"
+github "envoy/Embassy" "v4.1.6"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,5 @@
+github "hyperwallet/hyperwallet-ios-sdk" "1.0.1"
+github "hyperwallet/hyperwallet-ios-insight" "1.0.0-beta08"
 github "JanGorman/Hippolyte" "1.4.1"
 github "envoy/Ambassador" "v4.0.5"
 github "envoy/Embassy" "v4.1.6"

--- a/HyperwalletUISDK.podspec
+++ b/HyperwalletUISDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                  = 'HyperwalletUISDK'
-    spec.version               = '1.0.2'
+    spec.version               = '1.0.3'
     spec.summary               = 'Hyperwallet UI SDK for iOS to integrate with Hyperwallet Platform'
     spec.homepage              = 'https://github.com/hyperwallet/hyperwallet-ios-ui-sdk'
     spec.license               = { :type => 'MIT', :file => 'LICENSE' }

--- a/HyperwalletUISDK.xcodeproj/project.pbxproj
+++ b/HyperwalletUISDK.xcodeproj/project.pbxproj
@@ -5120,7 +5120,7 @@
 					"@executable_path/Frameworks",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				ONLY_ACTIVE_ARCH = NO;
 				PREPAID_CARD_TOKEN = "trm-token";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyperwallet.ui.sdk.Demo;
@@ -5155,7 +5155,7 @@
 					"@executable_path/Frameworks",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PREPAID_CARD_TOKEN = "trm-token";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyperwallet.ui.sdk.Demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5559,7 +5559,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.0.2;
+				CURRENT_PROJECT_VERSION = 1.0.3;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -5635,7 +5635,7 @@
 					"@executable_path/Frameworks",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				PREPAID_CARD_TOKEN = "trm-token";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyperwallet.ui.sdk.Demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -6048,7 +6048,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.0.2;
+				CURRENT_PROJECT_VERSION = 1.0.3;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -6117,7 +6117,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.0.2;
+				CURRENT_PROJECT_VERSION = 1.0.3;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;

--- a/HyperwalletUISDK.xcodeproj/project.pbxproj
+++ b/HyperwalletUISDK.xcodeproj/project.pbxproj
@@ -185,9 +185,6 @@
 		980B9AED251D446400653D1C /* ListTransferSourceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980B9AEA251D446400653D1C /* ListTransferSourceController.swift */; };
 		980C2E9525224D8300DFDC94 /* GetPrepaidCardSuccessResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = 980C2E9225224D6D00DFDC94 /* GetPrepaidCardSuccessResponse.json */; };
 		980C2E9625224F6E00DFDC94 /* PrepaidCardRepositoryRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980C2E8D25224C8200DFDC94 /* PrepaidCardRepositoryRequestHelper.swift */; };
-		980E7A312613BED800F0834B /* Swifter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD0313E325E4EAB600505BDA /* Swifter.xcframework */; };
-		980E7A682613CB1200F0834B /* Swifter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD0313E325E4EAB600505BDA /* Swifter.xcframework */; };
-		980E7A692613CB1200F0834B /* Swifter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FD0313E325E4EAB600505BDA /* Swifter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		983EF20F2526A950000A55B3 /* ListTransferDestinationPrepaidCardsOnly.json in Resources */ = {isa = PBXBuildFile; fileRef = 983EF20D2526A8EB000A55B3 /* ListTransferDestinationPrepaidCardsOnly.json */; };
 		984C47F22527E8A600CC442D /* PrepaidCardRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984C47F02527E89900CC442D /* PrepaidCardRepositoryTests.swift */; };
 		984C47F72527EC6100CC442D /* ListPrepaidCardResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = 984C47F32527EC5C00CC442D /* ListPrepaidCardResponse.json */; };
@@ -303,6 +300,10 @@
 		DB46798F2260380D00E1AF49 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DB46798D2260380D00E1AF49 /* LaunchScreen.storyboard */; };
 		DB4679992260386D00E1AF49 /* IntegratorAuthenticationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4679982260386D00E1AF49 /* IntegratorAuthenticationProvider.swift */; };
 		DB4BDFDF22D40B2B00761710 /* TransferMethodRepositoryFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4BDFDE22D40B2B00761710 /* TransferMethodRepositoryFactoryTests.swift */; };
+		DB4CA7F62E037278002896B5 /* Ambassador.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB4CA7F52E037278002896B5 /* Ambassador.xcframework */; };
+		DB4CA7F72E037278002896B5 /* Ambassador.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DB4CA7F52E037278002896B5 /* Ambassador.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DB4CA7FC2E03729F002896B5 /* Embassy.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB4CA7FB2E03729F002896B5 /* Embassy.xcframework */; };
+		DB4CA7FD2E03729F002896B5 /* Embassy.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DB4CA7FB2E03729F002896B5 /* Embassy.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DB5295DC22E22F0200657F50 /* UserReceiptResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = 07BE415E229DE181002DECAF /* UserReceiptResponse.json */; };
 		DB5295DD22E22F0200657F50 /* UserReceiptNextPageResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = 0743EFA022A59EE100C089EE /* UserReceiptNextPageResponse.json */; };
 		DB5295DE22E22F0200657F50 /* UserReceiptDetails.json in Resources */ = {isa = PBXBuildFile; fileRef = 4AEBF0FE22AA8CB000C664D3 /* UserReceiptDetails.json */; };
@@ -749,12 +750,23 @@
 				98CACE1B24A6CFD10000F2B0 /* Receipt.framework in Embed Frameworks */,
 				98CACE1D24A6CFD30000F2B0 /* ReceiptRepository.framework in Embed Frameworks */,
 				FD03135225E4E97200505BDA /* Insights.xcframework in Embed Frameworks */,
-				980E7A692613CB1200F0834B /* Swifter.xcframework in Embed Frameworks */,
 				FD48732425DE98D6005855B6 /* HyperwalletSDK.xcframework in Embed Frameworks */,
 				98CACE2524A6CFD80000F2B0 /* TransferRepository.framework in Embed Frameworks */,
 				98DAF67E24B7E33600A8D7CA /* Common.framework in Embed Frameworks */,
 				98CACE2324A6CFD70000F2B0 /* TransferMethodRepository.framework in Embed Frameworks */,
 				98CACE1F24A6CFD40000F2B0 /* Transfer.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB4CA7F82E037278002896B5 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				DB4CA7FD2E03729F002896B5 /* Embassy.xcframework in Embed Frameworks */,
+				DB4CA7F72E037278002896B5 /* Ambassador.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1048,6 +1060,8 @@
 		DB4679BE2261083F00E1AF49 /* UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFont.swift; sourceTree = "<group>"; };
 		DB4679C2226113D100E1AF49 /* HyperwalletBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperwalletBundle.swift; sourceTree = "<group>"; };
 		DB4BDFDE22D40B2B00761710 /* TransferMethodRepositoryFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferMethodRepositoryFactoryTests.swift; sourceTree = "<group>"; };
+		DB4CA7F52E037278002896B5 /* Ambassador.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Ambassador.xcframework; path = Carthage/Build/Ambassador.xcframework; sourceTree = "<group>"; };
+		DB4CA7FB2E03729F002896B5 /* Embassy.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Embassy.xcframework; path = Carthage/Build/Embassy.xcframework; sourceTree = "<group>"; };
 		DB5295FB22E233AB00657F50 /* HyperwalletReceiptUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperwalletReceiptUI.swift; sourceTree = "<group>"; };
 		DB5295FE22E2344B00657F50 /* HyperwalletTransferMethodUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperwalletTransferMethodUI.swift; sourceTree = "<group>"; };
 		DB551F4922E1316400DD65C2 /* Common.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Common.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1271,7 +1285,6 @@
 		DCF74267257E305600A5295A /* ListTransferMethodResponsePaperCheck.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ListTransferMethodResponsePaperCheck.json; sourceTree = "<group>"; };
 		DCF74269257E68F500A5295A /* ListTransferMethodResponseWithoutPaperCheck.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ListTransferMethodResponseWithoutPaperCheck.json; sourceTree = "<group>"; };
 		FD03133D25E4E96700505BDA /* Hippolyte.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Hippolyte.xcframework; path = Carthage/Build/Hippolyte.xcframework; sourceTree = "<group>"; };
-		FD0313E325E4EAB600505BDA /* Swifter.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Swifter.xcframework; path = Carthage/Build/Swifter.xcframework; sourceTree = "<group>"; };
 		FD09389125EE252E00AAA29B /* BalanceRepository.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BalanceRepository.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD09389325EE252E00AAA29B /* BalanceRepository.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BalanceRepository.h; sourceTree = "<group>"; };
 		FD0938B025EE279700AAA29B /* BalanceRepositoryFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BalanceRepositoryFactory.swift; sourceTree = "<group>"; };
@@ -1392,7 +1405,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				980E7A312613BED800F0834B /* Swifter.xcframework in Frameworks */,
+				DB4CA7FC2E03729F002896B5 /* Embassy.xcframework in Frameworks */,
+				DB4CA7F62E037278002896B5 /* Ambassador.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1406,7 +1420,6 @@
 				98CACE2224A6CFD70000F2B0 /* TransferMethodRepository.framework in Frameworks */,
 				98CACE2424A6CFD80000F2B0 /* TransferRepository.framework in Frameworks */,
 				FD03135125E4E97200505BDA /* Insights.xcframework in Frameworks */,
-				980E7A682613CB1200F0834B /* Swifter.xcframework in Frameworks */,
 				98CACE2024A6CFD50000F2B0 /* TransferMethod.framework in Frameworks */,
 				98DAF67D24B7E33600A8D7CA /* Common.framework in Frameworks */,
 				98CACE1E24A6CFD40000F2B0 /* Transfer.framework in Frameworks */,
@@ -2373,7 +2386,8 @@
 		DBAE17C0225F136A00C5CC60 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				FD0313E325E4EAB600505BDA /* Swifter.xcframework */,
+				DB4CA7FB2E03729F002896B5 /* Embassy.xcframework */,
+				DB4CA7F52E037278002896B5 /* Ambassador.xcframework */,
 				FD03133D25E4E96700505BDA /* Hippolyte.xcframework */,
 				FD4872FE25DE97BB005855B6 /* Insights.xcframework */,
 				FD48726D25DE975C005855B6 /* HyperwalletSDK.xcframework */,
@@ -2922,6 +2936,7 @@
 				DB2587F72261BFF100E6236B /* Sources */,
 				DB2587F82261BFF100E6236B /* Frameworks */,
 				DB2587F92261BFF100E6236B /* Resources */,
+				DB4CA7F82E037278002896B5 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -4349,7 +4364,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -4383,7 +4401,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -4417,7 +4438,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -4522,6 +4546,10 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4557,6 +4585,10 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4592,6 +4624,10 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -4693,7 +4729,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4726,7 +4765,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4759,7 +4801,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -4859,7 +4904,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -4892,7 +4940,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -4925,7 +4976,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -4997,7 +5051,6 @@
 		DB2588032261BFF100E6236B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = 86FDS64Z83;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5025,7 +5078,6 @@
 		DB2588042261BFF100E6236B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = 86FDS64Z83;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5074,6 +5126,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyperwallet.ui.sdk.Demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_TOKEN = "usr-your-user-token";
@@ -5104,6 +5160,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyperwallet.ui.sdk.Demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_TOKEN = "usr-your-user-token";
@@ -5139,7 +5199,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5172,7 +5234,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5205,7 +5269,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5305,6 +5371,10 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5337,6 +5407,10 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5369,6 +5443,10 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5515,7 +5593,6 @@
 		DB5E93192261C3CC00CD57F6 /* XCUITest */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = 86FDS64Z83;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -5563,6 +5640,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyperwallet.ui.sdk.Demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_TOKEN = "usr-token";
@@ -5599,6 +5680,10 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5632,6 +5717,10 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5665,6 +5754,10 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5767,7 +5860,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5800,7 +5896,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -5833,7 +5932,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -6069,7 +6171,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyperwallet.ios.BalanceRepository;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6104,7 +6209,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyperwallet.ios.BalanceRepository;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6139,7 +6247,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hyperwallet.ios.BalanceRepository;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/HyperwalletUISDK.xcodeproj/project.pbxproj
+++ b/HyperwalletUISDK.xcodeproj/project.pbxproj
@@ -1062,6 +1062,7 @@
 		DB4BDFDE22D40B2B00761710 /* TransferMethodRepositoryFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferMethodRepositoryFactoryTests.swift; sourceTree = "<group>"; };
 		DB4CA7F52E037278002896B5 /* Ambassador.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Ambassador.xcframework; path = Carthage/Build/Ambassador.xcframework; sourceTree = "<group>"; };
 		DB4CA7FB2E03729F002896B5 /* Embassy.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Embassy.xcframework; path = Carthage/Build/Embassy.xcframework; sourceTree = "<group>"; };
+		DB4CA8082E0992E2002896B5 /* Cartfile  */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Cartfile "; sourceTree = "<group>"; };
 		DB5295FB22E233AB00657F50 /* HyperwalletReceiptUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperwalletReceiptUI.swift; sourceTree = "<group>"; };
 		DB5295FE22E2344B00657F50 /* HyperwalletTransferMethodUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyperwalletTransferMethodUI.swift; sourceTree = "<group>"; };
 		DB551F4922E1316400DD65C2 /* Common.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Common.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2641,6 +2642,7 @@
 		DBD2667F2261A601002973C3 /* Deployment */ = {
 			isa = PBXGroup;
 			children = (
+				DB4CA8082E0992E2002896B5 /* Cartfile  */,
 				DBD266812261A611002973C3 /* Cartfile */,
 				DBD266832261A611002973C3 /* Cartfile.private */,
 				98541F142273D72C007D4238 /* CHANGELOG.md */,

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Adding one or more of these frameworks allows users to explore the particular fu
 ### Carthage
 Specify it in your Cartfile:
 ```ogdl
-github "hyperwallet/hyperwallet-ios-ui-sdk" "1.0.2"
+github "hyperwallet/hyperwallet-ios-ui-sdk" "1.0.3"
 ```
 Add desired modules using the `Linked Frameworks and Libraries` option to make them available in the app.
 Use `import <module-name>` to add the dependency within a file
@@ -42,13 +42,13 @@ Use `import <module-name>` to add the dependency within a file
 ### CocoaPods
 - Install a specific framework (install one or more frameworks based on your requirement)
 ```ruby
-pod "HyperwalletUISDK/TransferMethod", "1.0.2"
-pod "HyperwalletUISDK/Transfer", "1.0.2"
-pod "HyperwalletUISDK/Receipt", "1.0.2"
+pod "HyperwalletUISDK/TransferMethod", "1.0.3"
+pod "HyperwalletUISDK/Transfer", "1.0.3"
+pod "HyperwalletUISDK/Receipt", "1.0.3"
 ```
 - To install all available modules (TransferMethod, Transfer, Receipt)
 ```ruby
-pod 'HyperwalletUISDK', '~> 1.0.2'
+pod 'HyperwalletUISDK', '~> 1.0.3'
 ```
 Use `import HyperwalletUISDK` to add the dependency within a file.
 

--- a/UITests/BaseTests/BaseTest.swift
+++ b/UITests/BaseTests/BaseTest.swift
@@ -46,7 +46,6 @@ class BaseTests: XCTestCase {
 
     override func setUp() {
         mockServer = HyperwalletMockWebServer.shared
-        mockServer.setUp()
 
         mockServer.setupStub(url: "/rest/v3/users/usr-token/authentication-token",
                              filename: "AuthenticationTokenWalletModelResponse",
@@ -103,9 +102,5 @@ class BaseTests: XCTestCase {
 
     func clickBackButton() {
         app.navigationBars.buttons[Common.navBackButton].tap()
-    }
-
-    override func tearDown() {
-        mockServer.tearDown()
     }
 }

--- a/UITests/BaseTests/BaseTest.swift
+++ b/UITests/BaseTests/BaseTest.swift
@@ -45,7 +45,7 @@ class BaseTests: XCTestCase {
      }
 
     override func setUp() {
-        mockServer = HyperwalletMockWebServer()
+        mockServer = HyperwalletMockWebServer.shared
         mockServer.setUp()
 
         mockServer.setupStub(url: "/rest/v3/users/usr-token/authentication-token",

--- a/UITests/Helper/HyperwalletMockWebServer.swift
+++ b/UITests/Helper/HyperwalletMockWebServer.swift
@@ -1,6 +1,6 @@
-import Foundation
-import Embassy
 import Ambassador
+import Embassy
+import Foundation
 
 enum HTTPMethod {
     case get
@@ -8,8 +8,8 @@ enum HTTPMethod {
     case put
 }
 
+// swiftlint:disable force_try
 final class HyperwalletMockWebServer {
-    
     private var server: HTTPServer!
     private var router: Router! = Router()
     private var loop: EventLoop!
@@ -30,17 +30,16 @@ final class HyperwalletMockWebServer {
         thread.start()
     }
     
-    func setupStub(url: String, filename: String, method: HTTPMethod) {
+    func setupStub(url: String, filename: String, method: HTTPMethod, statusCode: Int = 200) {
         let filePath = testBundle.path(forResource: filename, ofType: "json")
         let fileUrl = URL(fileURLWithPath: filePath!)
         
         do {
             let data = try Data(contentsOf: fileUrl, options: .uncached)
-            guard let json = dataToJSON(data: data) else { return }
+            guard let json = dataToJSON(data: data)
+            else { return }
             
-            print("ADD url:"  + url + ", JSON: \(json)")
-            router[url] = JSONResponse() { _ -> Any in
-                print("url:"  + url + ", JSON: \(json)")
+            router[url] = JSONResponse(statusCode: statusCode) { _ -> Any in
                 return json
             }
         } catch {
@@ -53,12 +52,12 @@ final class HyperwalletMockWebServer {
         let fileUrl = URL(fileURLWithPath: filePath!)
         do {
             let data = try Data(contentsOf: fileUrl, options: .uncached)
-            guard let json = dataToJSON(data: data) else { return }
+            guard let json = dataToJSON(data: data)
+            else { return }
             
             router[url] = JSONResponse(statusCode: statusCode) { _ -> Any in
                 return json
             }
-            
         } catch {
             print("Error info: \(error)")
         }
@@ -68,9 +67,9 @@ final class HyperwalletMockWebServer {
         router[url] = DataResponse(
             statusCode: 204,
             statusMessage: "No Content",
-            contentType:  "application/json",
+            contentType: "application/json",
             headers: []
-        ) { environ, sendData in
+        ) { _, sendData in
             sendData(Data())
         }
     }
@@ -93,3 +92,4 @@ final class HyperwalletMockWebServer {
         return nil
     }
 }
+// swiftlint:enable force_try

--- a/UITests/Helper/TransferMethod/AddTransferMethod.swift
+++ b/UITests/Helper/TransferMethod/AddTransferMethod.swift
@@ -325,10 +325,12 @@ class AddTransferMethod {
     }
 
     func setCity(_ city: String) {
+        app.scroll(to: cityInput)
         cityInput.clearAndEnterText(text: city)
     }
 
     func setPostalCode(_ postalCode: String) {
+        app.scroll(to: postalCodeInput)
         postalCodeInput.clearAndEnterText(text: postalCode)
     }
 

--- a/UITests/TransferFunds/TransferUserFundsConfirmationTest.swift
+++ b/UITests/TransferFunds/TransferUserFundsConfirmationTest.swift
@@ -108,12 +108,12 @@ class TransferUserFundsConfirmationTest: BaseTests {
                              filename: "ListMoreThanOneTransferMethod",
                              method: HTTPMethod.get)
 
-        mockServer.setupStub(url: "/rest/v3/transfers",
-                             filename: "AvailableFundMultiCurrencies",
-                             method: HTTPMethod.post)
-
         mockServer.setupStub(url: "/rest/v3/transfers/trf-token/status-transitions",
                              filename: "TransferStatusQuoted",
+                             method: HTTPMethod.post)
+        
+        mockServer.setupStub(url: "/rest/v3/transfers",
+                             filename: "AvailableFundMultiCurrencies",
                              method: HTTPMethod.post)
 
         transferFundMenu.tap()
@@ -201,12 +201,14 @@ class TransferUserFundsConfirmationTest: BaseTests {
                              filename: "ListTransferMethodMoreThanOneVenmo",
                              method: HTTPMethod.get)
 
-        mockServer.setupStub(url: "/rest/v3/transfers",
-                             filename: "AvailableFundsVenmoDetails",
-                             method: HTTPMethod.post)
+       
 
         mockServer.setupStub(url: "/rest/v3/transfers/trf-token/status-transitions",
                              filename: "TransferStatusQuoted",
+                             method: HTTPMethod.post)
+        
+        mockServer.setupStub(url: "/rest/v3/transfers",
+                             filename: "AvailableFundsVenmoDetails",
                              method: HTTPMethod.post)
 
         transferFundMenu.tap()

--- a/UITests/TransferFunds/TransferUserFundsConfirmationTest.swift
+++ b/UITests/TransferFunds/TransferUserFundsConfirmationTest.swift
@@ -201,8 +201,6 @@ class TransferUserFundsConfirmationTest: BaseTests {
                              filename: "ListTransferMethodMoreThanOneVenmo",
                              method: HTTPMethod.get)
 
-       
-
         mockServer.setupStub(url: "/rest/v3/transfers/trf-token/status-transitions",
                              filename: "TransferStatusQuoted",
                              method: HTTPMethod.post)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ end
 lane :unit_tests do
   run_tests(
     project: "HyperwalletUISDK.xcodeproj",
-    devices: ['iPhone 15 Pro'],
+    devices: ['iPhone 16 Pro'],
     derived_data_path: './output',
     scheme: "HyperwalletUISDK",
     configuration: 'Debug',
@@ -18,7 +18,7 @@ end
 lane :ui_tests do
   run_tests(
     project: "HyperwalletUISDK.xcodeproj",
-    devices: ['iPhone 15 Pro Max'],
+    devices: ['iPhone 16 Pro Max'],
     scheme: "Demo",
     configuration: 'XCUITest',
     number_of_retries: 3,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ end
 lane :unit_tests do
   run_tests(
     project: "HyperwalletUISDK.xcodeproj",
-    devices: ['iPhone 16 Pro'],
+    devices: ['iPhone 15 Pro'],
     derived_data_path: './output',
     scheme: "HyperwalletUISDK",
     configuration: 'Debug',
@@ -18,7 +18,7 @@ end
 lane :ui_tests do
   run_tests(
     project: "HyperwalletUISDK.xcodeproj",
-    devices: ['iPhone 16 Pro Max'],
+    devices: ['iPhone 15 Pro'],
     scheme: "Demo",
     configuration: 'XCUITest',
     number_of_retries: 3,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ end
 lane :unit_tests do
   run_tests(
     project: "HyperwalletUISDK.xcodeproj",
-    devices: ['iPhone 15 Pro'],
+    devices: ['iPhone 16 Pro'],
     derived_data_path: './output',
     scheme: "HyperwalletUISDK",
     configuration: 'Debug',
@@ -18,7 +18,7 @@ end
 lane :ui_tests do
   run_tests(
     project: "HyperwalletUISDK.xcodeproj",
-    devices: ['iPhone 15 Pro'],
+    devices: ['iPhone 16 Pro'],
     scheme: "Demo",
     configuration: 'XCUITest',
     number_of_retries: 3,


### PR DESCRIPTION
## Ticket: LI-97987

## Sumarry
Swifter SDK Embeds Trojan CDN - [Polyfill.io](http://polyfill.io/) (Supply Chain Attack)
More detials here 
[Data Theorem](https://www.securetheorem.com/mobile-secure/security/issues?parent=iOS&filter_by_named_filter=mobile_app%3A3e0eb85e-c9af-4e89-883d-573588ee998c&mobile_app_id=6533725597859840&named_filter_parent=IOS&securityFindingId=000322) 

The App is using a 3rd Party SDK called "Swifter", which embeds staticfile.org (part of the polyfill.io CDN), a popular javascript hosting service that was compromised and is known to be serving malicious code.

### Changes
- Replace Swifter by envoy/Ambassador